### PR TITLE
Enable to connect to open source digdag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,3 +115,24 @@ You can start workflow session by using ``Client.start_attempt``.
 
    # Wait attempt until finish. This may require few minutes.
    attempt = client.wait_attempt(attempt)
+
+
+Connect to open source digdag
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Since Treasure Workflow is hosted digdag, tdworkflow is compatible with open source digdag.
+
+.. note::
+   Open source digdag API may be different with Treasure Workflow API so that tdworkflow might not work with some API of opensource digdag.
+
+Here is the example code to connect local digdag server.
+
+.. code-block:: python
+
+    >>> import tdworkflow
+    >>> import requests
+    >>> session = requests.Session()
+    >>> client = tdworkflow.client.Client(
+    ... endpoint="localhost:65432", apikey="", _session=session, scheme="http")
+    >>> client.projects()
+    [Project(id=1, name='python-tdworkflow', revision='134fe2f9-ded3-4e7c-af8e-8a82d55d688b', archiveType='db', archiveMd5='5Lc6F6m3DtmBN4DA5MzK8A==', createdAt='2019-11-01T13:03:26Z', deletedAt=None, updatedAt='2019-11-01T13:03:26Z')]

--- a/tdworkflow/client.py
+++ b/tdworkflow/client.py
@@ -751,6 +751,7 @@ class Client(AttemptAPI, WorkflowAPI, ProjectAPI, ScheduleAPI, SessionAPI, LogAP
         apikey: Optional[str] = None,
         user_agent: Optional[str] = None,
         _session: Optional[requests.Session] = None,
+        scheme: str = "https",
     ) -> None:
         """Treasure Workflow REST API client
 
@@ -765,6 +766,8 @@ class Client(AttemptAPI, WorkflowAPI, ProjectAPI, ScheduleAPI, SessionAPI, LogAP
         :type user_agent: Optional[str], optional
         :param _session: HTTP object to make requests
         :type _session: Optional[requests.Session]
+        :param scheme: URI scheme default: "https"
+        :type scheme: str
         :raises ValueError: If ``site`` is unknown name.
         :raises ValueError: If ``apikey`` is empty and environment variable
                             ``TD_API_KEY`` doesn't exist
@@ -809,7 +812,7 @@ class Client(AttemptAPI, WorkflowAPI, ProjectAPI, ScheduleAPI, SessionAPI, LogAP
         _session.mount("http://", HTTPAdapter(max_retries=retries))
 
         self._http = _session
-        self.api_base = f"https://{self.endpoint}/api/"
+        self.api_base = f"{scheme}://{self.endpoint}/api/"
 
     @property
     def http(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,28 +16,6 @@ from tdworkflow.session import Session
 from tdworkflow.workflow import Workflow
 
 
-def test_create_client():
-    client = Client(site="us", apikey="APIKEY")
-    assert client.site == "us"
-    assert client.endpoint == "api-workflow.treasuredata.com"
-    assert client.apikey == "APIKEY"
-    assert isinstance(client.http, requests.Session)
-    assert client.http.headers["Authorization"] == "TD1 APIKEY"
-    assert client.http.headers["User-Agent"] == f"tdworkflow/{tdworkflow.__version__}"
-    assert client.api_base == "https://api-workflow.treasuredata.com/api/"
-
-
-def test_create_client_with_endpoint():
-    client = Client(endpoint="digdag.example.com", apikey="APIKEY")
-    assert client.site == "us"
-    assert client.endpoint == "digdag.example.com"
-    assert client.apikey == "APIKEY"
-    assert isinstance(client.http, requests.Session)
-    assert client.http.headers["Authorization"] == "TD1 APIKEY"
-    assert client.http.headers["User-Agent"] == f"tdworkflow/{tdworkflow.__version__}"
-    assert client.api_base == "https://digdag.example.com/api/"
-
-
 RESP_DATA_GET_0 = {
     "projects": [
         {
@@ -226,6 +204,38 @@ def prepare_mock(
         response.raise_for_status.side_effect = side_effect
     if json:
         response.headers = {"Content-Type": "application/json"}
+
+
+def test_create_client():
+    client = Client(site="us", apikey="APIKEY")
+    assert client.site == "us"
+    assert client.endpoint == "api-workflow.treasuredata.com"
+    assert client.apikey == "APIKEY"
+    assert isinstance(client.http, requests.Session)
+    assert client.http.headers["Authorization"] == "TD1 APIKEY"
+    assert client.http.headers["User-Agent"] == f"tdworkflow/{tdworkflow.__version__}"
+    assert client.api_base == "https://api-workflow.treasuredata.com/api/"
+
+
+def test_create_client_with_endpoint():
+    client = Client(endpoint="digdag.example.com", apikey="APIKEY")
+    assert client.site == "us"
+    assert client.endpoint == "digdag.example.com"
+    assert client.apikey == "APIKEY"
+    assert isinstance(client.http, requests.Session)
+    assert client.http.headers["Authorization"] == "TD1 APIKEY"
+    assert client.http.headers["User-Agent"] == f"tdworkflow/{tdworkflow.__version__}"
+    assert client.api_base == "https://digdag.example.com/api/"
+
+
+def test_create_client_with_scheme():
+    session = requests.Session()
+    client = Client(
+        endpoint="localhost:65432", apikey="", _session=session, scheme="http"
+    )
+    assert client.endpoint == "localhost:65432"
+    assert client.api_base == "http://localhost:65432/api/"
+    assert "Authorization" not in client.http.headers
 
 
 class TestProjectAPI:


### PR DESCRIPTION
This change introduces an experimental feature to connect OSS digdag. Since tdworkflow is based on digdag v0.10.x API, there might be incompatible API with OSS digdag i.e. 0.9.x.

Leveraging `requests.Session`, tdworkflow can avoid setting Authorization header.

```py
>>> import tdworkflow
>>> import requests
>>> session = requests.Session()
>>> client = tdworkflow.client.Client(
... endpoint="localhost:65432", apikey="", _session=session, scheme="http")
>>> client.projects()
[Project(id=1, name='python-tdworkflow', revision='134fe2f9-ded3-4e7c-af8e-8a82d55d688b', archiveType='db', archiveMd5='5Lc6F6m3DtmBN4DA5MzK8A==', createdAt='2019-11-01T13:03:26Z', deletedAt=None, updatedAt='2019-11-01T13:03:26Z')]
```