### PR TITLE
#8 Add status field to Attempt

### DIFF
--- a/tdworkflow/attempt.py
+++ b/tdworkflow/attempt.py
@@ -23,6 +23,7 @@ class Attempt:
     params: Dict = None
     createdAt: datetime = None
     finishedAt: datetime = None
+    status: str = ""
 
     def __post_init__(self):
         self.id = int(self.id)
@@ -36,6 +37,7 @@ class Attempt:
         self.cancelRequested = bool(self.cancelRequested)
         self.createdAt = parse_iso8601(self.createdAt)
         self.finishedAt = parse_iso8601(self.finishedAt)
+        self.status = self.status
 
     @property
     def session_id(self):
@@ -79,3 +81,4 @@ class Attempt:
         self.params = other_attempt.params
         self.createdAt = other_attempt.createdAt
         self.finishedAt = other_attempt.finishedAt
+        self.status = other_attempt.status

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -152,6 +152,7 @@ RESP_DATA_GET_6 = {
             },
             "createdAt": "2019-11-01T07:00:00Z",
             "finishedAt": "2019-11-01T07:06:38Z",
+            "status": "running",
         }
     ]
 }


### PR DESCRIPTION
Here is the test result.

```
$ pytest
======================================================================= test session starts =======================================================================
platform darwin -- Python 3.7.4, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
rootdir: /Users/toru/td/fix/tdworkflow
plugins: mock-3.2.0
collected 37 items                                                                                                                                                

tests/test_client.py ....................................                                                                                                   [ 97%]
tests/test_util.py .                                                                                                                                        [100%]

======================================================================= 37 passed in 0.69s ========================================================================

```

Here is the current API response.

```
$ curl -X PUT 'https://api-workflow.treasuredata.com/api/attempts' -H 'AUTHORIZATION: TD1 xxxxxxxxx' -H 'Accept: application/json' -H 'Content-Type: application/json' -d "{ \"params\": { \"msg\": \"Hello from REST API.\" }, \"sessionTime\": \"2019-05-01T13:38:52+09:00\", \"workflowId\": \"157647\"}"
{"status":"success","id":"137993537","index":1,"project":{"id":"40357","name":"select1"},"workflow":{"name":"select1","id":"157647"},"sessionId":"25387320","sessionUuid":"85d67ad5-63a0-4e6d-a70a-977d921545d9","sessionTime":"2019-05-01T04:38:52+00:00","retryAttemptName":null,"done":true,"success":true,"cancelRequested":false,"params":{"msg":"Hello from REST API."},"createdAt":"2020-07-15T02:04:54Z","finishedAt":"2020-07-15T02:04:58Z"}
```

I also confirmed the following.

```
$ python
Python 3.7.4 (default, Jan  8 2020, 13:38:53) 
[Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import tdworkflow
>>> client = tdworkflow.client.Client(site='us', apikey='xxxxxxx')
>>> project = client.project(40357)
>>> workflows = client.project_workflows(project)
>>> client.start_attempt(workflows[0])
Attempt(id=137998370, sessionId='25388816', sessionUuid='02bd30b8-e0ea-4f23-8f9b-8653a8f6006b', sessionTime=datetime.datetime(2020, 7, 15, 2, 45, 51, tzinfo=datetime.timezone.utc), workflow=Workflow(id=2919386, name='select1', project=None, timezone='', config=None, revision='', createdAt=None, deletedAt=None, updatedAt=None), project=Project(id=40357, name='select1', revision='', archiveType='', archiveMd5='', createdAt=None, deletedAt=None, updatedAt=None), index=1, retryAttemptName=None, done=False, success=False, cancelRequested=False, params={}, createdAt=datetime.datetime(2020, 7, 15, 2, 45, 52, tzinfo=datetime.timezone.utc), finishedAt=None, status='running')
>>> attempt = client.start_attempt(workflows[0])
```

Can u merge this fix?