### PR TITLE
Changed iso parsing method for Python3.6+

### DIFF
--- a/tdworkflow/util.py
+++ b/tdworkflow/util.py
@@ -5,6 +5,7 @@ import os
 import re
 import tarfile
 from datetime import datetime, timedelta, timezone
+from dateutil.parser import isoparse
 from typing import List, Optional
 
 logger = logging.getLogger(__name__)
@@ -42,7 +43,7 @@ def parse_iso8601(target: str) -> Optional[datetime]:
     if not target:
         return None
 
-    return datetime.fromisoformat(target.replace("Z", "+00:00"))
+    return isoparse(target.replace("Z", "+00:00"))
 
 
 def to_iso8601(dt: datetime) -> str:


### PR DESCRIPTION
Result for python3.6 testing:
```
============================= test session starts ==============================
platform linux -- Python 3.6.12, pytest-6.2.2, py-1.10.0, pluggy-0.13.0
rootdir: /home/hcsolomon/tdworkflow
plugins: celery-4.3.0, mock-3.5.1
collected 38 items                                                             

tests/test_client.py .....................................               [ 97%]
tests/test_util.py .                                                     [100%]

============================== 38 passed in 0.36s ==============================
```

Result for python3.7 testing:
```
============================= test session starts ==============================
platform linux -- Python 3.7.6, pytest-5.3.5, py-1.8.1, pluggy-0.13.1
rootdir: /home/hcsolomon/tdworkflow
plugins: openfiles-0.4.0, hypothesis-5.5.4, remotedata-0.3.2, astropy-header-0.1.2, arraydiff-0.3, doctestplus-0.5.0, mock-3.5.1
collected 38 items                                                             

tests/test_client.py .....................................               [ 97%]
tests/test_util.py .                                                     [100%]

============================== 38 passed in 0.30s ==============================
```