### PR TITLE
add request parameters to client.project_sessions.

### DIFF
--- a/tdworkflow/client.py
+++ b/tdworkflow/client.py
@@ -438,7 +438,7 @@ class ProjectAPI:
         if page_size:
             params["page_size"] = page_size
         project_id = project.id if isinstance(project, Project) else project
-        r = cast(ListOfDict, self.get(f"projects/{project_id}/sessions"))
+        r = cast(ListOfDict, self.get(f"projects/{project_id}/sessions", params=params))
         if r:
             return [Session.from_api_repr(**s) for s in r["sessions"]]
         else:


### PR DESCRIPTION
Hi,

I was trying to retrieve a large list of sessions and noticed that the `page_size` parameter of the `project_sessions` method was not working.