### PR TITLE
Use GNU_FORMAT in tarfile to avoid '././@PaxHeader' in archives

### DIFF
--- a/tdworkflow/util.py
+++ b/tdworkflow/util.py
@@ -16,7 +16,7 @@ def archive_files(target_dir: str, exclude_patterns: List[str]) -> io.BytesIO:
 
     target_dir_path = Path(target_dir)
     _bytes = io.BytesIO()
-    with tarfile.open(mode="w:gz", fileobj=_bytes) as tar:
+    with tarfile.open(mode="w:gz", fileobj=_bytes, format=tarfile.GNU_FORMAT) as tar:
         for current_dir, directories, files in os.walk(target_dir_path):
             for file_or_dir in [*directories, *files]:
                 file_path = Path(os.path.join(current_dir, file_or_dir))


### PR DESCRIPTION
## Summary
This merge request updates the `archive_files` function to use the `GNU_FORMAT` when creating tar archives. The current tar file creation process leads to the inclusion of unwanted '././@PaxHeader' directories in the tarballs. These directories are empty and serve no purpose in our context, potentially causing confusion and issues with tarball consumers.

## Problem
When archiving files using the default tar format, the Python `tarfile` library adds `PaxHeader` directories to store extended header information. This behavior, while compliant with POSIX standards, is unnecessary for our use case and results in additional, unneeded directories in our archives.

## Solution
By setting the `format` parameter of the `tarfile.open` method to `tarfile.GNU_FORMAT`, we force the use of the GNU tar format. This format does not use `PaxHeader` directories to store extended headers, thus preventing their creation. This change leads to the generation of cleaner archives, avoiding the inclusion of these empty directories.

## Impact
This change will make our tar archives simpler and potentially more compatible with systems that do not handle the `PaxHeader` directories properly. It will ensure that only the necessary files are included in the archives, without additional metadata directories.

## Testing
The change has been tested by creating archives with various sets of files and examining the contents of the resulting tarballs. No `PaxHeader` directories were included in any of the tested archives, confirming that the change achieves its intended effect.
